### PR TITLE
Fixed typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ Icon
 bower_components
 node_modules/
 db/
-client/lib
+client/libs
 
 # Floobits
 .floo


### PR DESCRIPTION
We'll need to manually remove the bower components from the pubilc/lib folder, had a typo in .gitignore which caused the bower stuff to be committed. Noooo!!!!
